### PR TITLE
Release 0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 
 Read the complete specs online at [sdmp.github.io](http://sdmp.github.io)
 or [on GitHub](./index.md).
+
+Build and launch this [jekyll site](http://jekyllrb.com/) using the command: `bundle exec jekyll serve`

--- a/index.md
+++ b/index.md
@@ -16,13 +16,14 @@ peer-to-peer network.
 * [License](#license) - Software license is basically public domain
 * [Release Cycle](#release-cycle) - The SDMP uses the semver approach
 * [Overview](#overview) - General overview and terminology
+* [Message Format](#message-format) - Format of messages passed around the network
 * [Cryptography](#cryptography) - The foundation of the SDMP is strong cryptography
-* [Resources](#resources) - Resources available within the SDMP
-* [Control Resources](#control-resources) - Creating users and nodes, establishing trust levels and connections
-* [Document Resources](#document-resources) - Public or encrypted resources, typically with human-readable content
-* [Publish/Synchronize](#publishsynchronize) - Publishing and synchronizing messages between peers
 * [Network](#network) - Establishing a network connection between peers
 * [Request/Response](#requestresponse) - Making and responding to network requests
+* [Resources](#resources) - Resources available within the SDMP
+* [Document Resources](#document-resources) - Public or encrypted resources, typically with human-readable content
+* [Control Resources](#control-resources) - Creating users and nodes, establishing trust levels and connections
+* [Publish/Synchronize](#publishsynchronize) - Publishing and synchronizing messages between peers
 
 ---
 
@@ -53,25 +54,28 @@ this document) are published and released under the [Very Open License](vol).
 
 ## Release cycle
 
-Updates will follow the [Semantic Versioning 2.0.0](http://semver.org/) approach, with only
-a major and minor number. The summary of that is: Minor number bumps are for non-breaking changes,
+Updates to the specifications will follow the [Semantic Versioning 2.0.0](http://semver.org/) approach.
+with only a major and minor number. The summary of that is: Minor number bumps are for non-breaking changes,
 while major number bumps are not backwards compatible.
 
-Updates for spelling and grammar will **not** bump the minor number.
+Updates for spelling and grammar which are completely backwards compatible will **not** bump the minor number.
 
 The scope and purpose of the SDMP is very limited, therefore it is anticipated that version
 number bumps will be very infrequent.
+
+**Note:** While still in draft (e.g. `0.x`), spelling and naming changes to variables which render the
+specifications backwards incompatible will **not** bump the major version.
 
 ---
 
 ## Get involved
 
-* Read through this entire document and make sure it is readable, consistent, and sane.
+* Read through this entire document and make sure it is human-readable, consistent, and sane.
 * [File issues][sdmpissues] if you find anything wrong or questionable, anywhere on this page.
 * Create [pull requests][sdmppullrequest] if you spot anything wrong or missing and you want to
 	propose a fix, including spelling or grammar errors! (Please make pull requests against
 	the `development` branch.)
-* If you have questions, you can even [file issues][sdmpissues] for those!
+* If you have questions, you can even [file issues][sdmpissues] for those, too!
 
 ---
 
@@ -80,7 +84,7 @@ number bumps will be very infrequent.
 There are two identities: the *user* and the *node*.
 
 * The *user* is the actual person or organization, and has one master public/private key.
-* The *node* is the application used to create messages, and has a separate public/private key.
+* The *node* is the application used to create messages, and has its own public/private key.
 
 There are two relationships:
 
@@ -89,86 +93,283 @@ There are two relationships:
 * A *connection* is between a user and another user. Users indicate connections in order to
 	allow synchronization of messages.
 
-Publishing messages:
+### Publishing messages:
 
-When a user [publishes](#publishsynchronize) a message, that message is sent to the intended recipient, and
-to all the nodes of the *user connections* of the user publishing the message. This is done so that
-when the recipient is offline, they can still retrieve the message once they are back online.
+When a user [publishes](#publishsynchronize) a message, that message is sent to the nodes of the
+recipient, *and* to the nodes of the *connections*. This is done so that when the recipient is
+offline, they can still retrieve the message once they are back online.
 
-Network connection:
+### Network connection:
 
 Before a network connection is established, each node must *already* have the public key of the
-other. This simplifies the connection process greatly, and allows a normal [Diffie-Helman][w_diffiehelman]
-handshake, with the packets encrypted to the node's key.
+other. This allows a [Diffie-Helman][w_diffiehelman] handshake (self-signed with the node's key)
+to establish an asymmetric key, which is used for that connection session.
+
+---
+
+## Message format
+
+Most data passed across the network will be [YAML][w_yaml] streams.
+
+Where the term `YAML message` is used, it is meant a valid YAML stream
+with the following additional restrictions:
+
+* Multi-document YAML streams are **not** allowed.
+* The YAML stream must use the start and end boundary characters, `---` and `...`,
+	respectively. (See the [YAML specs][yamlboundaries] for more information on
+	the boundary characters.)
+* Comments inside the YAML stream are **not** allowed.
+* More precisely, **only** values which are actual YAML properties or values are allowed.
 
 ---
 
 ## Cryptography
 
-The SDMP uses industry-standard cryptographic techniques to keep the network
-traffic secure, to strongly encrypt messages, and to verify a users identity.
+The SDMP uses industry-standard cryptographic techniques to keep the network traffic
+secure, to strongly encrypt messages, and to verify users and nodes identities.
 
 ### RSA public/private keys
 
 Where the phrase `public key`, `private key`, or `key pair` is used, it is meant
-an asymmetric [RSA][w_rsa] key pair.
+that section or set of an asymmetric [RSA][w_rsa] key pair.
 
-The bit length of the RSA key **must** be at least 2048 bits.
+The bit length of the RSA key **must** be *at least* 2048 bits.
 
 ### Hashing
 
 Where the phrase `hash` or `digest` is used, it is meant the [`SHA-256`][w_sha2] hashing
-algorithm as specified in [FIPS PUB 180-2](fips180), encoded to lower-case hexadecimal.
+algorithm as specified in [FIPS PUB 180-2][fips180], encoded to lower-case hexadecimal.
 
 ### Key hashing
 
-Where a *key hash* is specified, it is meant the *PGP fingerprint*.
+Where the phrase `key hash` is used, it is meant the *PGP fingerprint*.
 
 ### PGP fingerprint
 
-Where a PGP fingerprint is used, it is the complete V4 fingerprint as specified in
-[RFC 4880](https://tools.ietf.org/html/rfc4880#section-12.2), encoded to lower-case
+Where a PGP fingerprint is used, it **must** be the complete V4 fingerprint as specified
+in [RFC 4880](https://tools.ietf.org/html/rfc4880#section-12.2), encoded to lower-case
 hexadecimal, with no spaces or semicolons.
 
-E.g., `cd92815bf6273acbaf834b9faed277c722068291`.
+For example: `cd92815bf6273acbaf834b9faed277c722068291`
 
 ### AES encryption
 
-Where the phrase "session key" is used, it is meant an [AES][w_aes] compatible key of **at least** 256 bits.
+Where the phrase `session key` is used, it is meant an [AES][w_aes] compatible key.
+
+The bit length of the session key **must** be *at least* 256 bits.
+
+---
+
+## Network
+
+Network connections are made between nodes, and secured using a self-signed [Diffie-Helman][w_diffiehelman]
+handshake to establish the session key.
+
+### Nodes must have keys
+
+Before a network connection is established, each node **must** already have the public key
+of the other.
+
+### Diffie-Helman handshake review
+
+The generalized [Diffie-Helman][w_diffiehelman] key exchange looks like:
+
+1. Alice and Bob agree to use `p` and `g`
+2. Alice chooses secret `a` and sends Bob `A`, where `A=(g^a)%p`
+3. Bob chooses secret `b` and sends Alice `B`, where `B=(g^b)%p`
+4. Alice computes `s`, where `s=(B^a)%p`
+5. Bob computes `s`, where `s=(A^b)%p`
+6. Alice and Bob share the secret `s`, which is the session key
+
+### Self-signed Diffie-Helman connection message
+
+Each node makes a *connection message*, which is a YAML document containing the
+information necessary for the Diffie-Helman exchange, signed by the node creating
+the connection message.
+
+The node chooses a secret `n` and calculates `N` where `N=(g^n)%p`.
+
+The values of `g`, `p`, and `N`, along with the [key fingerprint](#cryptography) of
+the node public key, and the key fingerprint of the user the node represents, are
+placed inside a [YAML message](#message-format) with the following requirements:
+
+* At the root of the YAML stream is a single object named `connection`.
+* The **required** `connection` object properties are: `g`, `p`, and `N`.
+* The value of `g` is integer-encoded.
+* The values of `p` and `N` are `binary` encoded, according to [YAML specs](http://yaml.org/type/binary.html).
+
+This resulting YAML message is signed using the key of the node creating the message,
+and is transmitted in clear-text across the network.
+
+Placing any additional information or metadata in the message which would identify the
+node creating the message is considered an error, and if this state is detected the
+connection **must** be dropped.
+
+### Connection message validation
+
+When a node receives a connection message, it drops the connection under the
+following circumstances:
+
+* If the connection message cannot be decrypted by the receiving node.
+* If the node cannot verify the signature in the message for **any** reason, including but not limited to:
+	- malformed data,
+	- an improperly generated signature, or
+	- the node does not have the public key of the node which generated the message.
+* If the node does not accept the values of `g`, `p`, or `N` for any reason.
+
+### Connection dropping
+
+When dropping a connection during connection message validation, the following process
+is followed in **all** cases:
+
+1. The plaintext message `nope` is transmitted.
+2. The connection is then dropped.
+
+It is **not** permitted that a node transmit **any** other information concerning
+the cause of the drop.
+
+### Network traffic
+
+After both nodes have exchanged connection messages, they have the necessary information to calculate
+the shared session key.
+
+All network traffice past this point for this connection **must** be encrypted using this session key.
+
+Prior to encryption, network data must be padded to the nearest 256 bytes with the method specified
+in [RFC 5652][rfc5652].
+
+### Connection overview
+
+The process for establishing a secure connection is as follows:
+
+1. The local node creates a TCP connection to the remote node.
+2. The local node sends a connection message to the remote node.
+3. The remote node verifies the connection message, dropping the connection if there is an error.
+4. The remote node sends a connection message to the local node.
+5. The local node verifies the connection message, dropping the connection if there is an error.
+6. The local and remote node calculate the shared session key.
+7. All future messages are padded and then encrypted using the shared session key.
+
+---
+
+## Request/Response
+
+After a secure connection is established, messages between nodes follow a request/response
+approach like a simplified HTTP: all requests are made by the node initiating the connection,
+and responses contain the data or some status code.
+
+### Request document
+
+A *request document* is any [YAML message](#message-format) sent by the node which initialized
+the network connection, with the following additional requirements:
+
+The request document **requires** the property `request` to be present at the root
+of the YAML stream. This property has the following values:
+
+* `node` *[string, required]* The key fingerprint of the node initiating the request.
+* `representing` *[string, required]* The key fingerprint of the user which the node is
+	representing for this request.
+* `type` *[string, required]* The type of request. **Must** be one of the following:
+	- `resource` : Requests for a specific resource.
+	- `synchronize` : Requests to synchronize resource stacks.
+
+#### `type: resource`
+
+When the `type` property of the `request` object is `resource`, the following additional
+fields are **required** on the `request` object:
+
+* `author` : The key fingerprint of the user who published the resource.
+* `resource` : The resource identifier of the requested resource.
+
+#### `type: synchronize`
+
+When the `type` property of the `request` object is `synchronize`, the [stack synchronization](#publishsynchronize)
+properties **must** be present.
+
+The following additional properties are reserved for use on the `request` object:
+
+* `start_version` *[string, required]* The version of the stack requested to start
+	from. This is typically the most recent stack version of the responding node
+	as known by the requesting node.
+* `maximum_list_size` *[integer, optional]* The requesting node may request the responding
+	node limit the resource stack list size in the response.
+
+### Response document
+
+A *response document* is a type of [YAML message](#message-format) sent by a node in
+response to a request. There are three *types* of response documents:
+
+* The requested resource, in the case of a resource request, or
+* The requested synchronization information, in the case of a synchronization request, or
+* A generic response document containing a status, in all other cases.
+
+In the case where the response is the actual resource, it **must** be the **exact** published
+resource. No modifications of the resource are allowed, such as inserting additional headers,
+and the resource hash and signature should be verified by the receiving node.
+
+At the root of the YAML stream of all other response documents is the **required**
+property named `response`, with the following reserved properties:
+
+* `status` *[integer, required]* A status code loosely based on [HTTP status codes][w_httpcodes],
+	of one of the following possible values:
+	- `102` (Processing) - For throttling purposes, the responding node may use this status code to
+		inform the connecting node that the request will take some time. If this status is used,
+		the responding node **should** include a `delay` value on the `response` object.
+	- `200` (Okay) - The generic response when the request has been processed, and the
+		response has no errors.
+	- `304` (Not modified) - Used when a node makes a synchronization request and the `stack_version`
+		on the `request` object is still the most recent version.
+	- `400` (Bad request) - The responding node cannot or will not process the document due to
+		something that is perceived to be a client error, such as malformed message syntax, or
+		when the requesting node is not authorized for the request action.
+	- `404` (Not found) - Used in response to `read` actions, when the resource is not available.
+* `delay` *[integer, optional]* If the response `status` is `102`, the responding node **may**
+	include this property, which is the delay time in secods. The requesting node should respect
+	this delay, and wait for the specified number of seconds to make the same request.
+
+### Stack synchronization
+
+As part of the network protocol, nodes may [synchronize](#publishsynchronize) with each other
+their own list of published and known resources. Requests to synchronize set the request type
+to `synchronize`.
+
+For all request documents where the request type is `synchronize`, and for all responses
+to that request where the response status is `200`, the following properties are **required**
+on the `request` object, and on the `response` object:
+
+* `stack` *[object, required]* An object containing the following **required** fields:
+	- `current` *[string, required]* The current version of the node's version stack.
+	- `list` *[string list, required]* A partial *or* complete list of YAML `key: value`
+		pairs which are the values on the node's version stack, where the *key* is the
+		resource identifier, and the *value* is the resource author.
+	- `start` *[string, required]* The version used for the first value in the `list`
+		property, or `false` if the list starts at the zero-th version.
+	- `end` *[string, required]* The version of the node's version stack that is calculated
+		using the last value in the `list` property. E.g., if the `list` value contains all
+		values up to the current version, `end` would be identical to `current`.
+
+Although it is not required that a node calculate intermediate versions for the responding node, the
+information provided should be enough that the requesting node could recreate the entire resource stack.
 
 ---
 
 ## Resources
 
-Resources passed between nodes are signed YAML ([SYML][syml]) streams.
+Resources [published/synchronized](#publishsynchronize) between nodes **must** be [SYML][syml] streams
+conforming to the [YAML message](#message-format) restrictions. There are two types of resources
+published within the SDMP:
 
-### Resource types
+* [Document Resources](#document-resources) are the general message type, and may contain
+	public data, or data that is visible only to the intended recipient.
+* [Control Resources](#control-resources) are specific resource types, and contain information
+	establishing node and user identities, and authorizing relationships between the two.
 
-There are only two types of resources published within the SDMP: [controls](#control-resources)
-and [documents](#document-resources). Both of these are defined YAML/SYML streams.
+### Shared properties
 
-Control resources contain publically visible information about nodes, users, and relationships
-between the two.
+All resources have `resource` as a reserved property at the root of the YAML message. This property
+has the following reserved values:
 
-Document resources are the general message type, and may contain public data, or data that
-is visible only to the intended recipient.
-
-### YAML restrictions
-
-All resources **must** be valid [SYML][syml] streams, with the following additional
-**required** restrictions:
-
-* Multi-document YAML streams are **not** allowed.
-* Comments inside the YAML stream are **not** allowed.
-* More precisely, **only** values which are actual YAML properties or values are allowed.
-* A single property at the root of the YAML document named `resource` is **required** and **reserved**.
-
-### Properties of the `resource` object
-
-The following properties of the `resource` object are reserved for use within the SDMP:
-
-* `user` *[string, required]* The node sending a resource **must** include the key fingerprint
-	of the user that has authorized the node to publish the resource.
+* `user` *[string, required]* The key fingerprint of the user creating the resource.
 * `action` *[string, required]* Describes an action to take regarding a resource. **Must** be one
 	of the following values: `create`, `read`, `update`, or `delete`.
 * `versions` *[string collection, optionally required]* This property is **required** when
@@ -182,7 +383,7 @@ The following properties of the `resource` object are reserved for use within th
 
 ### Resource identifier
 
-The hash of the YAML file which is signed to generate the SYML signature is the *resource identifier*.
+The hash of the YAML message which is signed to generate the SYML signature is the *resource identifier*.
 
 ### URI: Uniform Resource Identifier
 
@@ -201,6 +402,63 @@ URIs have the two possible forms:
 * `sdmp://\<AUTHOR>/\<RESOURCE>` - Requests of this type should return the resource whose
 	resource identifier is `RESOURCE` and which has been published by the user
 	whose key fingerprint is `AUTHOR`.
+
+---
+
+
+TODO stopped here
+
+
+
+
+
+## Document Resources
+
+All resources published to the SDMP which are *not* control resources are called by
+the general name *document resource*.
+
+All document resources require the root `resource` object to have a property
+named `document`, which is an object containing minimal metadata about the resource.
+
+There are two types of resources: *public* and *encrypted/mixed*.
+
+### Encrypted/mixed documents
+
+Documents containing encrypted data have the property `encrypted` on the `document`
+object, which is the binary encoded encrypted message, equivalent to PGP unarmored
+encryption output.
+
+Because there is additional information available in the resource, it would be
+misleading to indicate that the resource itself was encrypted, and a properly
+functioning node application will **not** allow additional private metadata to
+be inserted into the resource.
+
+**Note:** Although the focus of the SDMP is not on anonymity, a properly functioning
+node application will **not** make visible the recipients of any private message.
+Exposing the recipients of a message makes the privacy of the users needlessly
+difficult to protect.
+
+### Public documents
+
+Resources which contain additional metadata or content which is not encrypted are
+considered *public* documents.
+
+To further indicate that a resource is public, the boolean property `public` **must**
+be set on the `document` object, and it **must** be set to `true`.
+
+### Etiquette for public vs private
+
+Publishing a resource containing a public document should be interpreted in much
+the same way as publishing a public blog post. The information in the resource
+should be considered available for general public viewing.
+
+Publishing a resource which has not been marked as public is much like sending
+an email: the recipient of the document must determine by context and discretion
+whether a message should be relayed in whole, in part, or not at all.
+
+Applications should make the distinction of public vs private clear to the
+user, primarily so that a user does not accidentally send a private message
+marked as public.
 
 ---
 
@@ -318,55 +576,6 @@ resources to or from that connection.
 
 ---
 
-## Document Resources
-
-Resources published to the SDMP which are not control resources are called "documents".
-
-All document resources require the root `resource` object to have a property
-named `document`, which is an object containing minimal metadata about the resource.
-
-There are two types of resources: *public* and *encrypted/mixed*.
-
-### Encrypted/mixed documents
-
-Documents containing encrypted data have the property `encrypted` on the `document`
-object, which is the binary encoded encrypted message, equivalent to PGP unarmored
-encryption output.
-
-Because there is additional information available in the resource, it would be
-misleading to indicate that the resource itself was encrypted, and a properly
-functioning node application will **not** allow additional private metadata to
-be inserted into the resource.
-
-**Note:** Although the focus of the SDMP is not on anonymity, a properly functioning
-node application will **not** make visible the recipients of any private message.
-Exposing the recipients of a message makes the privacy of the users needlessly
-difficult to protect.
-
-### Public documents
-
-Resources which contain additional metadata or content which is not encrypted are
-considered *public* documents.
-
-To further indicate that a resource is public, the boolean property `public` **must**
-be set on the `document` object, and it **must** be set to `true`.
-
-### Etiquette for public vs private
-
-Publishing a resource containing a public document should be interpreted in much
-the same way as publishing a public blog post. The information in the resource
-should be considered available for general public viewing.
-
-Publishing a resource which has not been marked as public is much like sending
-an email: the recipient of the document must determine by context and discretion
-whether a message should be relayed in whole, in part, or not at all.
-
-Applications should make the distinction of public vs private clear to the
-user, primarily so that a user does not accidentally send a private message
-marked as public.
-
----
-
 ## Publish/Synchronize
 
 The primary difficulty of publishing messages across a decentralized network is that sending
@@ -478,239 +687,6 @@ network connection or in a later network connection.
 See the [specifications](#requestresponse) for additional details on the request/response cycle
 for completely synchronizing a node's version stack.
 
----
-
-## Network
-
-All network connections are between nodes, and secured using the [Diffie-Helman](w_diffiehelman)
-key creation approach, with some minor modifications to authenticate the connecting node.
-
-### Nodes must have keys
-
-Before a network connection is established, each node **must** already have the public key
-of the other.
-
-### Connection is per user-authorization
-
-Although there is nothing preventing a node from being authorized by multiple users, a
-connection between nodes is established for a single user only.
-
-This means a node cannot publish messages for multiple users under the same connection.
-
-### Session key
-
-A symmetric connection-unique AES key is created for the session.
-
-Although there is no cryptographic function preventing key reuse, a properly functioning
-node will **not** reuse session keys. Session keys **must** be unique to the session.
-
-### Typical Diffie-Helman
-
-A review of the general [Diffie-Helman][w_diffiehelman] key exchange:
-
-1. Alice and Bob agree to use `p` and `g`
-2. Alice chooses secret `a` and sends Bob `A`, where `A=(g^a)%p`
-3. Bob chooses secret `b` and sends Alice `B`, where `B=(g^b)%p`
-4. Alice computes `s`, where `s=(B^a)%p`
-5. Bob computes `s`, where `s=(A^b)%p`
-6. Alice and Bob share the secret `s`, which is the session key
-
-### "Wrapped" Diffie-Helman
-
-In order to avoid a man-in-the-middle attack, the values used in the Diffie-Helman exchange are
-signed by the node initializing the connection, and are also encrypted to the receiving node.
-
-This method requires that each node have previously obtained and verified the others' public key.
-
-1. Alice has previously acquired and verified Bob's public key `bk`
-2. Bob has previously acquired and verified Alice's public key `ak`
-3. Alice and Bob agree to use `p` and `g`
-4. Alice creates an encrypted message for Bob
-	1. Alice chooses secret `a` and calculates `A`, where `A=(g^a)%p`
-	2. Alice signs `A` as `S_A` and encrypts `A,S_A` to Bob's public key as `{A,S_A}_bk`
-	3. Alice sends Bob the encrypted message `{A,S_A}_bk`
-5. Bob creates an encrypted message for Alice
-	1. Bob chooses secret `b` and calculates `B`, where `B=(g^b)%p`
-	2. Bob signs `B` as `S_B` and encrypts `B,S_A` to Alices's public key as `{B,S_B}_ak`
-	3. Bob sends Alice the encrypted message `{B,S_B}_ak`
-6. Alice decrypts `{B,S_B}_ak`, verifies `S_B`, and then computes `s`, where `s=(B^a)%p`
-7. Bob decrypts `{A,S_A}_bk`, verifies `S_A`, and then computes `s`, where `s=(A^b)%p`
-8. Alice and Bob share the secret `s`, which is the session key
-
-### Connection package
-
-The node chooses a secret `n` and calculates `N` where `N=(g^n)%p`.
-
-The values of `g`, `p`, and `N`, along with the [key fingerprint](#cryptography) of
-the node public key, and the key fingerprint of the user the node represents, are
-placed inside a YAML stream constructed according to the following rules:
-
-* The YAML stream contains a single document.
-* At the root of the YAML stream is a single object named `connection`.
-* The **required** `connection` object properties are: `g`, `p`, `N`, `node`, and `user`.
-* The value of `g` is integer-encoded.
-* The values of `p` and `N` are `binary` encoded, according to [YAML specs](http://yaml.org/type/binary.html).
-* The value of `node` is the key fingerprint string of the node initializing the connection.
-* The value of `user` is the key fingerprint of the user which the node is representing.
-
-This YAML stream is transformed into a [SYML][syml] file, being signed using
-the key identified by the `node` key fingerprint.
-
-Before being sent over the network, the SYML file is encrypted to the public key of the
-recipient node, using the following rules:
-
-* The SYML stream is zero-byte padded to the nearest `4096` byte block.
-* This stream is encrypted using the public key of the intended recipient node.
-
-This encrypted stream is the connection package.
-
-### Connection package validation
-
-When a node receives a connection package, it drops the connection under the
-following circumstances:
-
-* If the connection package cannot be decrypted by the node.
-* If the node cannot verify the signature in the SYML for **any** reason, including but not limited to:
-	- malformed data,
-	- an improperly generated signature, or
-	- the node does not have the public key of the node identified by the fingerprint.
-* If the node cannot verify that the connecting node has been authorized
-	by the user identified by the `user` value
-* If the node does not accept the values of `g`, `p`, or `N` for any reason.
-
-### Connection dropping
-
-When dropping a connection during connection package validation, the following process
-is followed in **all** cases:
-
-1. The plaintext message `nope` is transmitted.
-2. The connection is then dropped.
-
-It is **not** permitted that a node transmit **any** other information concerning
-the cause of the drop.
-
-### Connection procedure
-
-The process for establishing a secure connection is as follows:
-
-1. The local node creates a TCP connection to the remote node.
-2. The local node sends a connection package to the remote node.
-3. The remote node verifies the connection package, dropping the connection if there is an error.
-4. The remote node sends a connection package to the local node.
-5. The local node verifies the connection package, dropping the connection if there is an error.
-6. The local and remote node calculate the shared session key.
-
-All messages past this point **must** be encrypted to this session key.
-
----
-
-## Request/Response
-
-The request/response approach within the SDMP is modeled after the HTTP request/response method,
-in that a request either yields the  *exact* requested data or a response packet, e.g. "not found".
-The responding node may **not** modify the requested data in any way.
-
-### Request/Response format
-
-All requests **must** be valid [YAML](w_yaml) streams, and all responses **must** be either valid
-YAML, or a valid resource. YAML streams have the following additional **required** restrictions:
-
-* Multi-document YAML streams are **not** allowed.
-* Comments inside the YAML stream are **not** allowed.
-* More precisely, **only** values which are actual YAML properties or values are allowed.
-
-### Request documents
-
-A request document is any YAML stream sent by the node which initialized the network connection.
-
-At the root of the YAML stream is the **required** property `request`, with the following fields:
-
-* `type` *[string, required]* The type of request. **Must** be one of the following:
-	- `resource` : Requests for a specific resource.
-	- `synchronize` : Requests to synchronize resource stacks.
-
-#### `type: resource`
-
-When the `type` property of the `request` object is `resource`, the following additional
-fields are **required** on the `request` object:
-
-* `author` : The key fingerprint of the user who published the resource.
-* `resource` : The resource identifier of the requested resource.
-
-#### `type: synchronize`
-
-When the `type` property of the `request` object is `synchronize`, the stack synchronization
-properties **must** be present.
-
-The following additional properties are reserved for use on the `request` object:
-
-* `start_version` *[string, required]* The version of the stack requested to start
-	from. This is typically the most recent stack version of the responding node
-	as known by the requesting node.
-* `maximum_list_size` *[integer, optional]* The requesting node may request the responding
-	node limit the resource stack list size in the response.
-
-### Stack synchronization properties
-
-When synchronizing version stacks between nodes, the following properties are **required** on
-the `request` object for requests where `type` is `synchronize`, and the `response` object
-for responses of synchronization requests:
-
-* `stack` : An object containing the following **required** fields:
-	- `current` : The current version of the node's version stack.
-	- `list` : A partial *or* complete list of YAML `key: value` pairs which are the
-		values on the version stack, where the *key* is the resource identifier, and
-		the *value* is the resource author.
-	- `start` : The version used for the first value in the `list` property, or `false`
-		if the list starts at the zero-th version.
-	- `end` : The version of the node's version stack that is calculated using the
-		last value in the `list` property. E.g., if the `list` value contains all
-		values up to the current version, `end` would be identical to `current`.
-
-Although it is not required that a node calculate intermediate versions for the responding node, the
-information provided should be enough that the requesting node could recreate the entire resource stack.
-
-### Response documents
-
-There are three types of responses:
-
-* The requested resource, in the case of a resource request, or
-* The requested synchronization information, in the case of a synchronization request, or
-* A generic document containing a status, in all other cases.
-
-In the case where the response is the actual resource, it must be the exact published
-resource. No modifications of the resource are allowed, and the resource hash and
-signature should be verified.
-
-At the root of the YAML stream of all other responses is the **required** property named `response`.
-
-The `response` object of all responses **must** have the property `status`, which is an
-integer status code (based on [HTTP status codes][w_httpcodes]) of one of the following
-possible values:
-
-* `102` (Processing) - For throttling purposes, the responding node may use this status code to
-	inform the connecting node that the request will take some time. If this status is used,
-	the responding node **should** include a `delay` value on the `response` object.
-* `200` (Okay) - The generic response when the request has been processed, and the
-	response has no errors.
-* `304` (Not modified) - Used when a node makes a synchronization request and the `stack_version`
-	on the `request` object is still the most recent version.
-* `400` (Bad request) - The responding node cannot or will not process the document due to
-	something that is perceived to be a client error, such as malformed message syntax, or
-	when the requesting node is not authorized for the request action.
-* `404` (Not found) - Used in response to `read` actions, when the resource is not available.
-
-Additional reserved properties on the `response` object:
-
-* `delay` *[integer, optional]* If the response `status` is `102`, the responding node **may**
-	include this property, which is the delay time in secods. The requesting node should respect
-	this delay, and wait for the specified number of seconds to make the same request.
-
-### Synchronization response
-
-If the responding node's stack version has changed, the response to a successful synchronization
-request **must** contain the stack synchronization properties set on the `response` object.
-
 [sdmpnpm]: https://github.com/sdmp/sdmp-npm
 [relayreader]: http://relayreader.com
 [sdmpissues]: https://github.com/sdmp/sdmp.github.io/issues
@@ -719,6 +695,8 @@ request **must** contain the stack synchronization properties set on the `respon
 [syml]: http://github.com/sdmp/signed-yaml
 [vol]: http://veryopenlicense.com/
 [fips180]: http://csrc.nist.gov/publications/fips/fips180-2/fips180-2.pdf
+[rfc5652]: https://tools.ietf.org/html/rfc5652#section-6.3
+[yamlboundaries]: http://www.yaml.org/spec/1.2/spec.html#id2760395
 [w_diffiehelman]: https://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange
 [w_yaml]: https://en.wikipedia.org/wiki/YAML
 [w_rsa]: https://en.wikipedia.org/wiki/RSA_(cryptosystem)

--- a/index.md
+++ b/index.md
@@ -548,8 +548,8 @@ placed inside a YAML stream constructed according to the following rules:
 * The YAML stream contains a single document.
 * At the root of the YAML stream is a single object named `connection`.
 * The **required** `connection` object properties are: `g`, `p`, `N`, `node`, and `user`.
-* The values of `g` and `p` are integer-encoded.
-* The value of `N` is `binary` encoded, according to [YAML specs](http://yaml.org/type/binary.html).
+* The value of `g` is integer-encoded.
+* The values of `p` and `N` are `binary` encoded, according to [YAML specs](http://yaml.org/type/binary.html).
 * The value of `node` is the key fingerprint string of the node initializing the connection.
 * The value of `user` is the key fingerprint of the user which the node is representing.
 


### PR DESCRIPTION
Many big changes happening now that I actually started coding the first implementation!
- Restructured document and rewrote sections to make the document structure flow better, and be more readable as well.
- Simplified YAML stream specs to be more consistent.
- Changed connection handshake method, I think it makes the connection process more clear and slightly more anonymized?
- Changed version numbering scheme, now that I'm getting into the serious stage.
- Fixed many broken links.
- Standardized the YAML message description.
- Standardized property descriptors to be `name *[type, required?]*`.
- Generalized resource documents, control resources are now a subset of resources in general.
