### PR TITLE
Use normal PEM key instead

### DIFF
--- a/core/cryptography/index.md
+++ b/core/cryptography/index.md
@@ -12,8 +12,8 @@ secure, to strongly encrypt messages, and to verify users and nodes identities.
 
 ## Keys
 
-Where the phrase `public key`, `private key`, `key pair`, or `RSA key pair` is used, it
-is meant that section or set of an asymmetric [RSA][w_rsa] key pair.
+Where the phrase `public key`, `private key`, `key pair`, or `RSA key pair` is
+used, it is meant that section or set of an asymmetric [RSA][w_rsa] key pair.
 
 The bit length of the RSA key must be *at least* 2048 bits.
 
@@ -32,21 +32,37 @@ property of the [identity](/core/identity) resource.
 
 ---
 
-## Key hashing
-
-Where the phrase `key hash` is used, it is meant the hash of the raw component of the
-*public* section of the RSA key pair.
-
----
-
 ## Key fingerprint
 
 Where the phrase `key fingerprint` is used, it is meant the key hash of the public
 key, encoded to [base64url][base64].
 
-E.g. a key fingerprint might look like:
+---
 
-	GlvAreTo0lCSyum7Wzh8pzhxYOOu-gMIgO2N95AAwAGP6-nR8xCvWvIW0t9rF_ZZfpCY_fDV38JDFKaOU91A8Q
+## Key hashing
+
+Where the phrase `key hash` is used, it is meant the generated from the UTF-8
+encoded `identity.key` property of the [identity](/core/identity) resource.
+
+E.g., for this example public key:
+
+	-----BEGIN PUBLIC KEY-----
+	MIIBIzANBgkqhkiG9w0BAQEFAAOCARAAMIIBCwKCAQIA2IxlYprmk/QpH1Rsz+WQ
+	m+WUYqR2xlV+xXDDOesMkwja32aUsjYe1kCS6nTqazEdy4m9utF3Eb3K5i8crTeg
+	g3GE+iJvYAgGXvMLiAb/Vrj0OqKv8m0BoZnxW7AjCURZ/tDn/YxNk5qnzhZLLMIT
+	zHQlZsKmBp/ZlrhTr4VgKxKlT4z/NNTPMnLHyFB4XVR6ge20nNWN6RJ03kk85+QI
+	mCGPU9Us70H6FQYI/e0Iq+64gw8PgpDZP+RSzYvpAr7alCj4/f0jeFzrz+lpsIzY
+	95bk2ucfasPYkH7m6UP1EmBfZJUn+pnX3CPpeex1h5RCKw4DoMSRgXrfoVjYv80w
+	QfUCAwEAAQ==
+	-----END PUBLIC KEY-----
+
+The property of `identity.key` would be:
+
+	-----BEGIN PUBLIC KEY-----\nMIIBIzANBgkqhkiG9w0BAQEFAAOCARAAMIIBCwKCAQIA2IxlYprmk/QpH1Rsz+WQ\nm+WUYqR2xlV+xXDDOesMkwja32aUsjYe1kCS6nTqazEdy4m9utF3Eb3K5i8crTeg\ng3GE+iJvYAgGXvMLiAb/Vrj0OqKv8m0BoZnxW7AjCURZ/tDn/YxNk5qnzhZLLMIT\nzHQlZsKmBp/ZlrhTr4VgKxKlT4z/NNTPMnLHyFB4XVR6ge20nNWN6RJ03kk85+QI\nmCGPU9Us70H6FQYI/e0Iq+64gw8PgpDZP+RSzYvpAr7alCj4/f0jeFzrz+lpsIzY\n95bk2ucfasPYkH7m6UP1EmBfZJUn+pnX3CPpeex1h5RCKw4DoMSRgXrfoVjYv80w\nQfUCAwEAAQ==\n-----END PUBLIC KEY-----
+
+And the hash (encoded to base64url) would be:
+
+	B_3ji9cDp1SJTyPnxuslQ66IT3zwEf4TvTEnGo60_2KGANVfhRY0XA2crFKIfq6edYcexkMYzfz6y3UsPZZLtw
 
 ---
 

--- a/core/identity/index.md
+++ b/core/identity/index.md
@@ -56,7 +56,7 @@ The string stored in `identity.key` would be:
 ###### `identity.fingerprint` *(string, required)*
 
 The [key fingerprint](/core/cryptography#key-fingerprint) of the public key
-in this object, whose octets are encoded as [unpadded base64url][base64].
+in this object.
 
 ---
 

--- a/core/identity/index.md
+++ b/core/identity/index.md
@@ -39,34 +39,24 @@ be generated after this date.
 
 ###### `identity.key` *(string, required)*
 
-The public key of a [globally](https://en.wikipedia.org/wiki/Earth) unique
-[key-pair](/core/cryptography#keys), which is equivalent to a normal OpenSSL
-PEM encoded key with the headers and newlines removed.
+The public key of a unique [key-pair](/core/cryptography#keys), which is
+equivalent to a normal OpenSSL PEM encoded key.
 
-For example, for a given PEM encoded key:
+For example, given a PEM encoded key (truncated with ellipsis
+for readability):
 
 	-----BEGIN PUBLIC KEY-----
-	MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxlDbEgpMlAm5LimQabMj
-	q8VPCbHlmFd6k/pTLAtF8YavVngSIByVQy+ozbIhksTTQkHpS/hxz5BpnqrziZ1b
-	ACbYNtjvF9qHnxrM6gqaoZE6bOqqKb2ZrSoWJW1rHy+3H7DVQ22H8SseDlma3K+a
-	WrVftkhMSPLQhNbqB8UYvP5i5gbkVzhVnZHBvsr41npQxImhMyMtS/olrSPAJqrl
-	dAZ9Km5edT3JpAjc9rPPoRWJSnzCBF4f/h28l9uVeljYUgvt+ZCPEz7SpjQN5dC6
-	NQ7BZIqPgiTfVcdCsDEti6bX2fFw7y3hMg9G4g7lLCwNCkRmLjZ1/7Zmabps0hc9
-	9wIDAQAB
+	MIIBIjAN...9wIDAQAB
 	-----END PUBLIC KEY-----
 
 The string stored in `identity.key` would be:
 
-	MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxlDbEgpMlAm5LimQabMjq8VPCbHlmFd6k/pTLAtF8YavVngSIByVQy+ozbIhksTTQkHpS/hxz5BpnqrziZ1bACbYNtjvF9qHnxrM6gqaoZE6bOqqKb2ZrSoWJW1rHy+3H7DVQ22H8SseDlma3K+aWrVftkhMSPLQhNbqB8UYvP5i5gbkVzhVnZHBvsr41npQxImhMyMtS/olrSPAJqrldAZ9Km5edT3JpAjc9rPPoRWJSnzCBF4f/h28l9uVeljYUgvt+ZCPEz7SpjQN5dC6NQ7BZIqPgiTfVcdCsDEti6bX2fFw7y3hMg9G4g7lLCwNCkRmLjZ1/7Zmabps0hc99wIDAQAB
+	-----BEGIN PUBLIC KEY-----\nMIIBIjAN...9wIDAQAB\n-----END PUBLIC KEY-----
 
 ###### `identity.fingerprint` *(string, required)*
 
 The [key fingerprint](/core/cryptography#key-fingerprint) of the public key
 in this object, whose octets are encoded as [unpadded base64url][base64].
-
-For example, for the above example key, the key fingerprint would be:
-
-	76gRSs9MkErqk89E7C6JNGaLnQThCBJMMU8qBrZof7ITwxkFVUyml1SgdIwhcLE4M9aJBB3fmjlqVHWJfwAWGw
 
 ---
 

--- a/schema/private_key/index.md
+++ b/schema/private_key/index.md
@@ -13,8 +13,9 @@ specified to hold the private section of the identity key pair.
 
 ## Publishing Not Allowed
 
-Private keys **must not** be published as resources, and applications
-should not allow private keys to be published.
+Private keys **must not** be published as resources, even if those
+private keys are password protected, and implementations should not
+allow private keys to be published.
 
 ---
 


### PR DESCRIPTION
- Identity schema uses unmodified PEM key. Fixes #30
- Clarify some details on private key. (Unfiled)
