### PR TITLE
Fix links to encrypted page

### DIFF
--- a/spec/0.12/core/index.md
+++ b/spec/0.12/core/index.md
@@ -29,7 +29,7 @@ There are two identities: users and nodes. Users authorize nodes to publish
 content. An identity is the container object with the public key of the user
 or node. Users authorize nodes to publish content by signing a trust.
 
-## [Encryption/Decryption](./encryption)
+## [Encryption/Decryption](./encrypted)
 
 Encryption of an object is done by generating an [AES][aes] key, encrypting
 the data to that key, and then encrypting the AES key to the public key of

--- a/spec/0.12/index.md
+++ b/spec/0.12/index.md
@@ -25,7 +25,7 @@ on how to get involved.
 	- [Cryptography](./core/cryptography): Key sizes and algorithms used.
 	- [Container](./core/container): Extendable, definable JSON object.
 	- [Identity](./core/identity): Public keys used to identify users or nodes.
-	- [Encrypted](./core/container): A container holding encrypted data.
+	- [Encrypted](./core/encrypted): A container holding encrypted data.
 	- [Signature](./core/signature): A container holding signed data.
 * [Journal](./journal): Publishing resources to other users or nodes.
 	- [Resource](./journal/resource): The thing published is a signature container.


### PR DESCRIPTION
While reading through to implement the encrypted section, I noticed a couple broken links.
